### PR TITLE
Add toSetEncoding

### DIFF
--- a/src/Spine/Data.hs
+++ b/src/Spine/Data.hs
@@ -14,6 +14,7 @@ module Spine.Data (
   , DecodeError (..)
   , renderKey
   , toEncoding
+  , toValidSetEncoding
   , fromEncoding_
   , fromEncoding
   , toItemEncoding
@@ -299,6 +300,29 @@ toEncoding k a =
     MapKey v ->
       (v, D.attributeValue & D.avM .~ a)
 
+toValidSetEncoding :: Key [a] -> [a] -> [(Text, D.AttributeValue)]
+toValidSetEncoding k a =
+  let
+    check x f =
+      case x of
+        [] ->
+          []
+        _ ->
+          f
+  in
+    case k of
+      IntSetKey v ->
+        check a $
+          [(v, D.attributeValue & D.avNS .~ (fmap renderIntegral a))]
+      StringSetKey v ->
+        check a $
+          [(v, D.attributeValue & D.avSS .~ a)]
+      StringListKey v ->
+        check a $
+          [(v, D.attributeValue & D.avL .~ fmap (\x -> D.attributeValue & D.avS .~ Just x) a)]
+      BinarySetKey v ->
+        check a $
+          [(v, D.attributeValue & D.avBS .~ a)]
 
 fromItemEncoding_ :: ItemKey a -> (HashMap Text D.AttributeValue) -> Maybe a
 fromItemEncoding_ k l =

--- a/test/Test/IO/Spine/Data.hs
+++ b/test/Test/IO/Spine/Data.hs
@@ -59,6 +59,10 @@ kStringSet :: Key [Text]
 kStringSet =
   StringSetKey "textsetx"
 
+kStringEmptySet :: Key [Text]
+kStringEmptySet =
+  StringSetKey "textsetx_empty"
+
 kBinary :: Key A.ByteString
 kBinary =
   BinaryKey "binaryx"
@@ -110,7 +114,7 @@ prop_encodings n b = forAll (elements muppets) $ \m ->
 
     -- put items
     void . A.send $ D.putItem (renderTableName testTableName)
-      & D.piItem .~ H.fromList [
+      & D.piItem .~ H.fromList ([
           toItemEncoding item m
         , toEncoding kInt n
         , toEncoding kIntSet set
@@ -123,7 +127,7 @@ prop_encodings n b = forAll (elements muppets) $ \m ->
         , toEncoding kNull ()
         , toEncoding kMap mapp
         , toEncoding kList listt
-        ]
+        ] <> toValidSetEncoding kStringEmptySet [])
 
     -- get items
     r <- A.send $ D.getItem (renderTableName testTableName)


### PR DESCRIPTION
! @markhibberd @charleso @jystic 

http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_PutItem.html
```
Attribute values cannot be null. String and Binary type attributes must have lengths greater than zero. Set type attributes cannot be empty.
```
/jury approved @markhibberd @ambiata-ci @jystic
/jury opted-out @charleso