### PR TITLE
Add string list key

### DIFF
--- a/src/Spine/Memory.hs
+++ b/src/Spine/Memory.hs
@@ -74,6 +74,8 @@ cast (Attribute k v) key =
       Just v
     (StringSetKey _, StringSetKey _) ->
       Just v
+    (StringListKey _, StringListKey _) ->
+      Just v
     (BinaryKey _, BinaryKey _) ->
       Just v
     (BinarySetKey _, BinarySetKey _) ->


### PR DESCRIPTION
Adding the document type list - http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes

Allows us to store an ordered collection of values. This is a fairly naive implementation that forces all the list elements to be the same type.

! @charleso @jystic 